### PR TITLE
feat: Preserve number of opponents on game reset

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -63,15 +63,16 @@ const Index = () => {
   }, [gameState.holeCards, gameState.communityCards, gameState.opponents, gameState.gameStage, gameState.position]);
 
   const resetGame = () => {
-    setGameState({
+    setGameState(prevState => ({
+      ...prevState, // Keep all previous state
       holeCards: [],
       communityCards: [],
       position: '',
-      opponents: 2,
+      // opponents: 2, // Keep the existing number of opponents
       potSize: 0,
       gameStage: 'preflop',
       bettingHistory: []
-    });
+    }));
     setWinProbability(null);
     setInsights([]);
   };


### PR DESCRIPTION
The reset game functionality now retains the previously set number of opponents instead of resetting it to the default value of 2.